### PR TITLE
Improve rewrite gating for vague first-turn queries

### DIFF
--- a/orchestration/rewrite.py
+++ b/orchestration/rewrite.py
@@ -24,15 +24,39 @@ class QueryWriter:
 
         # Cheap linguistic signals
         self.pronoun_pattern = re.compile(r"\b(it|they|that|this|those|these|he|she)\b", re.I)
+        self.vague_opening_pattern = re.compile(
+            r"^(help|i need help|can you help|question|doubt|not sure|explain this|"
+            r"tell me more|more details|details please|can you elaborate)",
+            re.I,
+        )
+        self.vague_placeholder_pattern = re.compile(
+            r"\b(something|anything|stuff|issue|problem|thing)\b",
+            re.I,
+        )
 
     def _needs_rewrite(self, query: str, history: str | None) -> bool:
         """
         Heuristic gate to decide whether rewrite is necessary.
         """
-        if not history:
+        query = query.strip()
+        if not query:
             return False
 
-        if len(query.strip()) < 12:
+        # First-turn safeguard: vague opening requests should still be rewritten.
+        # This helps retrieval when users start with generic asks and no context.
+        if not history:
+            if self.pronoun_pattern.search(query):
+                return True
+
+            if self.vague_opening_pattern.search(query):
+                return True
+
+            if len(query.split()) <= 8 and self.vague_placeholder_pattern.search(query):
+                return True
+
+            return False
+
+        if len(query) < 12:
             return True
 
         if self.pronoun_pattern.search(query):


### PR DESCRIPTION
### Motivation
- The `QueryWriter._needs_rewrite` heuristic previously returned `False` when no `history` was present, causing vague first-turn user messages to skip rewrite and degrade retrieval quality.
- The change ensures conversationally incomplete but vague initial queries (e.g. “help”, “can you help…”, or “something is wrong”) still trigger the rewriter so downstream retrieval can produce relevant results.

### Description
- Add two new regex signals `vague_opening_pattern` and `vague_placeholder_pattern` in `orchestration/rewrite.py` to detect generic opening intents and placeholder nouns.
- Normalize and trim the incoming `query` at the start of `_needs_rewrite` by calling `query = query.strip()` and early-returning if empty.
- Introduce first-turn safeguards in `_needs_rewrite` so that when `history` is missing, the method returns `True` if pronouns, vague openings, or short placeholder-heavy queries are detected while preserving existing multi-turn heuristics.
- Preserve prior checks for short queries, pronoun usage, and conversational continuations, with minimal cleanup to avoid double-trimming the query.

### Testing
- Compiled the modified file with `python -m compileall orchestration/rewrite.py`, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699f06083be48333bdbd04c8f5d41b5a)